### PR TITLE
fix: use bitnami legacy docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM bitnami/jsonnet:latest
+FROM bitnamilegacy/jsonnet:latest
 
 USER root
 


### PR DESCRIPTION
The current image does not exist anymore; it was migrated to `bitnamilegacy`. We need to find a permanent solution
<img width="923" height="338" alt="image" src="https://github.com/user-attachments/assets/715df392-1ea4-4221-89f7-b6ec6a3468ec" />
